### PR TITLE
Added CSSEditColors.dvtcolortheme

### DIFF
--- a/Xcode/CSSEditColors/CSSEditColors.dvtcolortheme
+++ b/Xcode/CSSEditColors/CSSEditColors.dvtcolortheme
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTConsoleDebuggerInputTextColor</key>
+	<string>0 0 0 1</string>
+	<key>DVTConsoleDebuggerInputTextFont</key>
+	<string>Menlo-Bold - 11.0</string>
+	<key>DVTConsoleDebuggerOutputTextColor</key>
+	<string>0 0 0 1</string>
+	<key>DVTConsoleDebuggerOutputTextFont</key>
+	<string>Menlo-Regular - 11.0</string>
+	<key>DVTConsoleDebuggerPromptTextColor</key>
+	<string>0.317071 0.437736 1 1</string>
+	<key>DVTConsoleDebuggerPromptTextFont</key>
+	<string>Menlo-Bold - 11.0</string>
+	<key>DVTConsoleExectuableInputTextColor</key>
+	<string>0 0 0 1</string>
+	<key>DVTConsoleExectuableInputTextFont</key>
+	<string>Menlo-Regular - 11.0</string>
+	<key>DVTConsoleExectuableOutputTextColor</key>
+	<string>0 0 0 1</string>
+	<key>DVTConsoleExectuableOutputTextFont</key>
+	<string>Menlo-Bold - 11.0</string>
+	<key>DVTConsoleTextBackgroundColor</key>
+	<string>0.999899 1 0.999842 1</string>
+	<key>DVTConsoleTextInsertionPointColor</key>
+	<string>0 0 0 1</string>
+	<key>DVTConsoleTextSelectionColor</key>
+	<string>0.576266 0.81005 1 1</string>
+	<key>DVTDebuggerInstructionPointerColor</key>
+	<string>0.705792 0.8 0.544 1</string>
+	<key>DVTSourceTextBackground</key>
+	<string>1.000 1.000 1.000</string>
+	<key>DVTSourceTextBlockDimBackgroundColor</key>
+	<string>0.5 0.5 0.5 1</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>0.278 0.278 0.278</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.5 0.5 0.5 1</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.738 0.837 0.979</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.512 0.423 0.157</string>
+		<key>xcode.syntax.character</key>
+		<string>0.434 0.575 0.234</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.659 0.659 0.659</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.659 0.659 0.659</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.528 0.624 0.732</string>
+		<key>xcode.syntax.entity</key>
+		<string>0.665 0.052 0.569</string>
+		<key>xcode.syntax.entity.start</key>
+		<string>0.665 0.052 0.569</string>
+		<key>xcode.syntax.identifier</key>
+		<string>0.000 0.000 0.000</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>0.639 0.289 0.142</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0.639 0.289 0.142</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>0.000 0.600 0.569</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0.000 0.600 0.569</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.200 0.600 0.800</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>0.200 0.600 0.800</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.391 0.220 0.125</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.391 0.220 0.125</string>
+		<key>xcode.syntax.identifier.plain</key>
+		<string>0.000 0.000 0.000</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>0.388 0.284 0.561</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0.388 0.284 0.561</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.323 0.475 0.706</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0.323 0.475 0.706</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.388 0.284 0.561</string>
+		<key>xcode.syntax.number</key>
+		<string>0.434 0.575 0.234</string>
+		<key>xcode.syntax.plain</key>
+		<string>0.278 0.278 0.278</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.393 0.221 0.124</string>
+		<key>xcode.syntax.string</key>
+		<string>0.434 0.575 0.234</string>
+		<key>xcode.syntax.url</key>
+		<string>0.000 0.200 1.000</string>
+		<key>xcode.syntax.url.mail</key>
+		<string>0.055 0.055 1.000</string>
+	</dict>
+	<key>DVTSourceTextSyntaxFonts</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>Monaco - 11.0</string>
+		<key>xcode.syntax.character</key>
+		<string>Monaco - 11.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>Monaco - 11.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>Monaco - 11.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>Monaco - 11.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>Monaco - 11.0</string>
+		<key>xcode.syntax.number</key>
+		<string>Monaco - 11.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>Monaco - 11.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>Monaco - 11.0</string>
+		<key>xcode.syntax.string</key>
+		<string>Monaco - 11.0</string>
+		<key>xcode.syntax.url</key>
+		<string>Monaco - 11.0</string>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Hey,

I really like your CSSEditColors theme! 
In fact, it's one of my favorite Xcode themes!

Sadly it does not work with newer versions of Xcode so I had to convert it with this tool: 

https://gist.github.com/mrevilme/488120

I think it's a good idea to add this directly to the repo... 

Cheers
